### PR TITLE
Adding fieldtype properties to configure the colorpicker

### DIFF
--- a/Colorpicker/meta.yaml
+++ b/Colorpicker/meta.yaml
@@ -4,3 +4,20 @@ description: Add colorpicker field type to Statamic V2
 url: https://github.com/lesaff/statamic-colorpicker
 developer: Rudy Affandi
 developer_url: https://github.com/lesaff
+fieldtype_fields:
+  format:
+    type: select
+    options:
+      hex: Hex
+      rgb: RGB
+    default: hex
+  control:
+    type: select
+    options:
+      hue: Hue
+      brightness: Brightness
+      saturation: Saturation
+      wheel: Wheel
+    default: hue
+  show_opacity:
+    type: toggle

--- a/Colorpicker/resources/assets/js/fieldtype.js
+++ b/Colorpicker/resources/assets/js/fieldtype.js
@@ -6,7 +6,10 @@ Vue.component('colorpicker-fieldtype', {
 
     data: function() {
         return {
-            show: true
+            show: true,
+            format: this.config.format,
+            control: this.config.control,
+            showOpacity: this.config.show_opacity
         };
     },
 
@@ -20,16 +23,16 @@ Vue.component('colorpicker-fieldtype', {
             animationEasing: 'swing',
             change: null,
             changeDelay: 0,
-            control: 'hue',
+            control: this.control,
             dataUris: true,
             defaultValue: '',
-            format: 'hex',
+            format: this.format,
             hide: null,
             hideSpeed: 100,
             inline: false,
             keywords: '',
             letterCase: 'lowercase',
-            opacity: false,
+            opacity: this.showOpacity,
             position: 'bottom left',
             show: null,
             showSpeed: 100,

--- a/Colorpicker/resources/lang/en/fieldtypes.php
+++ b/Colorpicker/resources/lang/en/fieldtypes.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'format' => 'The format string type used to represent the color',
+    'format_instruct' => 'Hex (eg. #000000), RGB (eg. rgba(0, 0, 0, 1))',
+    'control' => 'The type of color picking control to show the user',
+    'control_instruct' => '',
+    'show_opacity' => 'Whether to show the user an opacity slider',
+    'show_opacity_instruct' => 'This value can only be retrieved when the format is RGBA'
+];


### PR DESCRIPTION
Added properties for control, format and show opacity to fill out some features in the jQuery MiniColors library.

The field details are currently not being displayed correctly in Statamic 2.8.7 which is a known issue https://github.com/statamic/v2-hub/issues/1084